### PR TITLE
update to latest version of Botkit

### DIFF
--- a/start/package.json
+++ b/start/package.json
@@ -4,7 +4,7 @@
   "description": "A sample Slack Botkit bot.",
   "main": "kittenbot.js",
   "dependencies": {
-    "botkit": "0.4.0"
+    "botkit": "0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/step-1-token-file/package.json
+++ b/step-1-token-file/package.json
@@ -4,7 +4,7 @@
   "description": "A sample Slack Botkit bot.",
   "main": "kittenbot.js",
   "dependencies": {
-    "botkit": "0.4.0"
+    "botkit": "0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/step-2-docker/package.json
+++ b/step-2-docker/package.json
@@ -4,7 +4,7 @@
   "description": "A sample Slack Botkit bot.",
   "main": "kittenbot.js",
   "dependencies": {
-    "botkit": "0.4.0"
+    "botkit": "0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/step-3-kubernetes/package.json
+++ b/step-3-kubernetes/package.json
@@ -4,7 +4,7 @@
   "description": "A sample Slack Botkit bot.",
   "main": "kittenbot.js",
   "dependencies": {
-    "botkit": "0.4.0"
+    "botkit": "0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/step-4-update/package.json
+++ b/step-4-update/package.json
@@ -4,7 +4,7 @@
   "description": "A sample Slack Botkit bot.",
   "main": "kittenbot.js",
   "dependencies": {
-    "botkit": "0.4.0"
+    "botkit": "0.7.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Hello. I am a student who is in Google Study Jam about Kubernetes course.

What I want to suggest is to update the Botkit to latest version. If you accept my request, then it will absolutely help other users not to get confused and embarrassed. 

When I run 0.4 version Botkit(current version of yours), I get this message below.

Error in Botkit Studio Stats: Botkit Studio statistics are no longer supported. Update your project to the latest version of Botkit, or add `stats_optout: true` to your bot configuration.

Even if that message appears, when I test the slack bot, it works fine. But whenever I send a message that the bot can respond to the bot, that line above appears on the shell.

So without updating, whenever users initialize Botkit, they need to pass stats_optout parameter to Botkit.

Thanks for reading.
Best regards.

Donghoon Song.